### PR TITLE
add systemd fix for cloud-init on Fedora 20

### DIFF
--- a/openstack/fedora-20-x86_64/template.json
+++ b/openstack/fedora-20-x86_64/template.json
@@ -34,6 +34,7 @@
       "type": "shell",
       "scripts": [
         "../../scripts/openstack-yum.sh",
+        "../../scripts/cloud-init-systemd.sh",
         "../../scripts/cleanup.sh",
         "../../scripts/zerodisk.sh"
       ],

--- a/scripts/cloud-init-systemd.sh
+++ b/scripts/cloud-init-systemd.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+FILE=/usr/lib/systemd/system/cloud-init.service
+sed -i '/^Wants/s/$/ sshd.service/' $FILE
+grep -q Before $FILE && sed -i '/Before/s/$/ sshd.service/' $FILE ||  sed -i '/[Unit]/aBefore=sshd.service' $FILE


### PR DESCRIPTION
This is currently imported in our openstack as "Fedora 20 Jordan" if you'd like to test there.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1112817
