### PR TITLE
Fix Centos Initramfs Grow Root setup

### DIFF
--- a/scripts/openstack-yum.sh
+++ b/scripts/openstack-yum.sh
@@ -45,6 +45,7 @@ system_info:
 # vim:syntax=yaml
 EOF
 
+    rm -f anaconda* install.log* shutdown.sh
 fi
 
 # Don't edit grub on ppc64


### PR DESCRIPTION
Currently the centos packer script downloads a git repo in order to manage initramfs and cloud-init-growroot.

There is a dracut module that handles this without having to install git, clone a repo, and create a seperate initramfs.

It just installs `dracut-modules-growroot` and then tels dracut to recreate the initramfs.

Ihave tested this packer script and it grows the root partition without any issues.
