### PR TITLE
Centos 7 Scripts

### DIFF
--- a/http/ks-rhel-osl-qemu-7.cfg
+++ b/http/ks-rhel-osl-qemu-7.cfg
@@ -1,0 +1,127 @@
+# Base settings
+
+# Install OS instead of upgrade
+install
+cdrom
+# System keyboard
+keyboard us
+# System language
+lang en_US
+# Installation logging level
+logging --level=debug
+# Network information
+network --activate --device eth0 --onboot yes --bootproto=dhcp
+# System timezone
+timezone --utc  UTC
+# System bootloader configuration
+bootloader --location=mbr
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+
+# Disk partitioning information
+part / --fstype="ext4" --grow --size=100
+
+auth  --useshadow  --enablemd5
+# Firewall configuration
+firewall --disabled
+# Run the Setup Agent on first boot
+firstboot --disable
+#Root password
+rootpw --plain osuadmin
+# SELinux configuration
+selinux --permissive
+# Services
+services --disable=iscsi,iscsid,iptables,ip6tables
+reboot
+
+# Use network installation
+url --url=http://centos.osuosl.org/7/os/x86_64/
+repo --name=updates --baseurl=http://centos.osuosl.org/7/updates/x86_64/
+
+%packages
+@base
+-aspell
+-aspell-en
+-bluez-utils
+-bluez-gnome
+-bluez-hcidump
+-bluez-libs
+-ccid
+-coolkey
+-finger
+-gpm
+-iptstate
+-irda-utils
+-jwhois
+-lftp
+-logwatch
+-NetworkManager
+-pcmciautils
+-pinfo
+-rdate
+-rsh
+-telnet
+-firstboot-tui
+-system-config-network-tui
+-nfs-utils
+-nfs-utils-lib
+-policycoreutils
+-zsh
+-autofs
+-ksh
+-mdadm
+-smartmontools
+-udftools
+-ipsec-tools
+-nmap
+-samba-client
+-samba-common
+-xdelta
+-zisofs-tools
+-vnc
+-sendmail
+postfix
+acpid
+e2fsprogs
+sudo
+-rdist
+-ivtv-firmware
+%end
+
+%post
+
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+# Remove unwanted packages we don't use to save up space
+yum -y remove gnome-mount gtk2 cups cups-libs libX11 libXau libXdmcp atk \
+    alsa-lib audiofile portmap ppp avahi iwl*firmware* ql*firmware* \
+    ipw*firmware aic94xx-firmware atmel-firmware bfa-firmware \
+    libertas-usb8388-firmware rt61pci-firmware rt73usb-firmware \
+    xorg-x11-drv-ati-firmware zd1211-firmware wireless-tools
+
+# Set yum repos to us
+for i in CentOS-Base epel ; do
+      sed -i -e 's/^\(mirrorlist.*\)/#\1/g' /etc/yum.repos.d/$i.repo
+done
+sed -i -e 's/^#baseurl=.*$releasever\/os\/$basearch\//baseurl=http\:\/\/centos.osuosl.org\/$releasever\/os\/$basearch\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/updates\/$basearch\//baseurl=http\:\/\/centos.osuosl.org\/$releasever\/updates\/$basearch\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/addons\/$basearch\//baseurl=http\:\/\/centos.osuosl.org\/$releasever\/addons\/$basearch\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/extras\/$basearch\//baseurl=http\:\/\/centos.osuosl.org\/$releasever\/extras\/$basearch\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/centosplus\/$basearch\//baseurl=http\:\/\/centos.osuosl.org\/$releasever\/centosplus\/$basearch\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/contrib\/$basearch\//baseurl=http\:\/\/centos.osuosl.org\/$releasever\/contrib\/$basearch\//g' /etc/yum.repos.d/CentOS-Base.repo
+
+# Upgrade anything that may have been missed
+yum -y upgrade
+
+# Install epel repo (Right now it's in a beta directory)
+yum install -y http://dl.fedoraproject.org/pub/epel/beta/7/x86_64/epel-release-7-0.2.noarch.rpm
+yum makecache
+
+# Really disable selinux
+cat > /etc/selinux/config << EOM
+SELINUX=disabled
+SELINUXTYPE=targeted
+EOM
+
+%end

--- a/openstack/centos-7-x86_64/http/preseed.cfg
+++ b/openstack/centos-7-x86_64/http/preseed.cfg
@@ -1,0 +1,1 @@
+../../../http/ks-rhel-osl-qemu-7.cfg

--- a/openstack/centos-7-x86_64/template.json
+++ b/openstack/centos-7-x86_64/template.json
@@ -1,0 +1,44 @@
+{
+  "builders": [
+    {
+      "type": "qemu",
+      "name": "centos-7-x86_64",
+      "vm_name": "centos-7-x86_64",
+      "accelerator": "kvm",
+      "disk_size": 2048,
+      "format": "qcow2",
+      "headless": false,
+      "http_directory": "http",
+      "iso_checksum": "96de4f38a2f07da51831153549c8bd0c",
+      "iso_checksum_type": "md5",
+      "iso_url": "http://centos.osuosl.org/7/isos/x86_64/CentOS-7.0-1406-x86_64-NetInstall.iso",
+      "shutdown_command": "echo '/sbin/halt -h -p' > shutdown.sh; sh 'shutdown.sh'",
+      "ssh_password": "osuadmin",
+      "ssh_port": 22,
+      "ssh_username": "root",
+      "ssh_wait_timeout": "10000s",
+      "qemuargs": [ [ "-m", "1024m" ] ],
+      "boot_wait": "10s",
+      "boot_command": [
+        "<tab> text biosdevname=0 net.ifnames=0 ks=http://10.0.2.2:{{ .HTTPPort }}/preseed.cfg<enter><wait>"
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "file",
+      "source": "../../scripts/common.sh",
+      "destination": "/tmp/common.sh"
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "../../scripts/openstack-yum.sh",
+        "../../scripts/cloud-init-systemd.sh",
+        "../../scripts/cleanup.sh",
+        "../../scripts/zerodisk.sh"
+      ],
+        "execute_command": "sh '{{.Path}}'"
+    }
+  ]
+}

--- a/openstack/centos-7-x86_64/template.json
+++ b/openstack/centos-7-x86_64/template.json
@@ -7,7 +7,7 @@
       "accelerator": "kvm",
       "disk_size": 2048,
       "format": "qcow2",
-      "headless": false,
+      "headless": true,
       "http_directory": "http",
       "iso_checksum": "96de4f38a2f07da51831153549c8bd0c",
       "iso_checksum_type": "md5",

--- a/scripts/openstack-yum.sh
+++ b/scripts/openstack-yum.sh
@@ -2,17 +2,6 @@
 . /tmp/common.sh
 set -x
 
-if [ "$OS" == "centos" ] ; then
-    # Setup the cloud-init repo for cloud-init 0.7.x
-    cat << EOF >> /etc/yum.repos.d/cloud-init.repo
-[cloud-init]
-Name=Cloud Init Repo
-baseurl=http://repos.fedorapeople.org/repos/openstack/cloud-init/epel-6/
-gpgcheck=0
-enabled=1
-EOF
-fi
-
 # install cloud packages
 $yum update
 if [ "$(uname -m)" == "ppc64" ] ; then


### PR DESCRIPTION
I've added in the things necessary for Centos 7 to be built using packer.
In adding this, there was some further cleanup in the openstack-yum script for the centos 6 images.

The only outstanding issue is that epel-7 currently resides in ```/7/beta/$basearch``` and so an rpm must be installed in order to not mess up the epel script for centos 6. Once epel7 moves out of the beta folder, the rpm installation step will be removed.