### PR TITLE
Remove portmapper and Disable Time serving from chronyd

### DIFF
--- a/scripts/centos/cleanup.sh
+++ b/scripts/centos/cleanup.sh
@@ -19,3 +19,10 @@ for ndev in $(ls /etc/sysconfig/network-scripts/ifcfg-*); do
     sed -i '/^UUID/d' ${ndev}
   fi
 done
+
+# Disable any other running services
+
+systemctl stop rpcbind.service rpcbind.socket
+if [ -f /etc/chrony.conf ]
+  echo "\nport 0" >> /etc/chrony.conf
+fi


### PR DESCRIPTION
Here is where I got that chrony command from: https://chrony.tuxfamily.org/faq.html#_how_can_i_make_code_chronyd_code_more_secure