### PR TITLE
Don't perform cleanup on the openstack builds

### DIFF
--- a/centos-7.5-x86_64-newton-aio-openstack.json
+++ b/centos-7.5-x86_64-newton-aio-openstack.json
@@ -75,7 +75,6 @@
       "type": "shell",
       "execute_command": "echo 'centos' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
-        "scripts/centos/chef-zero-openstack-cleanup.sh",
         "scripts/centos/cleanup.sh",
         "scripts/common/minimize.sh"
       ]

--- a/centos-7.5-x86_64-newton-identity-openstack.json
+++ b/centos-7.5-x86_64-newton-identity-openstack.json
@@ -75,7 +75,6 @@
       "type": "shell",
       "execute_command": "echo 'centos' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
-        "scripts/centos/chef-zero-openstack-cleanup.sh",
         "scripts/centos/cleanup.sh",
         "scripts/common/minimize.sh"
       ]


### PR DESCRIPTION
I want to run the services on boot no matter what.