### PR TITLE
CentOS 7 for POWER9

### DIFF
--- a/centos-7-ppc64le-power9-openstack.json
+++ b/centos-7-ppc64le-power9-openstack.json
@@ -1,0 +1,58 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+        "c<wait5><wait10>",
+        "linux /ppc/ppc64/vmlinuz ro ",
+        "biosdevname=0 net.ifnames=0 ",
+        "ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos-7/ks-ppc64le-power9.cfg<enter>",
+        "initrd /ppc/ppc64/initrd.img<enter>",
+        "boot<enter><wait>"
+      ],
+      "accelerator": "kvm",
+      "boot_wait": "6s",
+      "disk_size": 3072,
+      "disk_interface": "virtio-scsi",
+      "headless": true,
+      "vnc_bind_address":"0.0.0.0",
+      "http_directory": "http",
+      "iso_checksum": "58d9af172656db71947b5db2d0d1f577217bbc1a86eada7ca3ce7bfcf7d7d9b4",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/7.5.1804/isos/power9/CentOS-7-Power9-NetInstall-1804.iso",
+      "output_directory": "packer-centos-7-ppc64le-power9-openstack",
+      "shutdown_command": "echo 'centos'|sudo -S shutdown -P now",
+      "qemuargs": [
+        [ "-m", "2048M" ],
+        [ "-boot", "strict=on" ]
+      ],
+      "qemu_binary": "/usr/libexec/qemu-kvm",
+      "machine_type": "pseries",
+      "ssh_password": "centos",
+      "ssh_port": 22,
+      "ssh_username": "centos",
+      "ssh_wait_timeout": "10000s",
+      "type": "qemu",
+      "vm_name": "packer-centos-7-ppc64le-power9-openstack"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo 'centos' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "scripts": [
+        "scripts/centos/fix-slow-dns.sh",
+        "scripts/common/sshd.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/centos/osuosl-altarch-power9.sh",
+        "scripts/centos/epel.sh",
+        "scripts/centos/openstack.sh",
+        "scripts/centos/cleanup.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "mirror": "http://centos-altarch.osuosl.org",
+    "image_name": "CentOS 7.5 LE (POWER9)"
+  }
+}

--- a/http/centos-7/ks-ppc64le-power9.cfg
+++ b/http/centos-7/ks-ppc64le-power9.cfg
@@ -1,0 +1,88 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp
+rootpw centos
+firewall --disabled
+selinux --permissive
+timezone UTC
+unsupported_hardware
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+part prepboot --fstype=prepboot --asprimary --size=8 --ondisk=sda
+part / --fstype="ext4" --grow --size=100 --ondisk=sda
+auth --enableshadow --passalgo=sha512 --kickstart
+firstboot --disabled
+reboot
+user --name=centos --plaintext --password centos
+url --url=http://centos-altarch.osuosl.org/7.5.1804/os/power9
+repo --name=updates --baseurl=http://centos-altarch.osuosl.org/7.5.1804/updates/power9
+
+%packages --nobase --ignoremissing
+openssh-clients
+sudo
+wget
+nfs-utils
+net-tools
+perl-libwww-perl
+bzip2
+vim
+rsync
+man
+man-pages
+parted
+-fprintd-pam
+-intltool
+
+# unnecessary firmware
+-aic94xx-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl1000-firmware
+-iwl100-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-libertas-sd8686-firmware
+-libertas-sd8787-firmware
+-libertas-usb8388-firmware
+-ql2100-firmware
+-ql2200-firmware
+-ql23xx-firmware
+-ql2400-firmware
+-ql2500-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+%end
+
+%post
+yum -y upgrade
+# update root certs
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
+# sudo
+echo "%centos ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/centos
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+%end

--- a/scripts/centos/osuosl-altarch-power9.sh
+++ b/scripts/centos/osuosl-altarch-power9.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eux
+
+# Use OSL for repos
+sed -i -e 's/^\(mirrorlist.*\)/#\1/g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/os\/power9\//baseurl=http\:\/\/centos-altarch.osuosl.org\/$releasever\/os\/power9\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/updates\/power9\//baseurl=http\:\/\/centos-altarch.osuosl.org\/$releasever\/updates\/power9\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/addons\/power9\//baseurl=http\:\/\/centos-altarch.osuosl.org\/$releasever\/addons\/power9\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/extras\/power9\//baseurl=http\:\/\/centos-altarch.osuosl.org\/$releasever\/extras\/power9\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/centosplus\/power9\//baseurl=http\:\/\/centos-altarch.osuosl.org\/$releasever\/centosplus\/power9\//g' /etc/yum.repos.d/CentOS-Base.repo
+sed -i -e 's/^#baseurl=.*$releasever\/contrib\/power9\//baseurl=http\:\/\/centos-altarch.osuosl.org\/$releasever\/contrib\/power9\//g' /etc/yum.repos.d/CentOS-Base.repo


### PR DESCRIPTION
CentOS 7 uses a 4.14 kernel to enable POWER9 so we need to create a separate
image just for that for now so that we can boot it properly.