### PR TITLE
added template for power9 ubuntu image

### DIFF
--- a/scripts/ubuntu/cleanup-power9.sh
+++ b/scripts/ubuntu/cleanup-power9.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Delete all Linux headers
+dpkg --list \
+  | awk '{ print $2 }' \
+  | grep 'linux-headers' \
+  | xargs apt-get -y purge;
+
+# Remove specific Linux kernels, such as linux-image-3.11.0-15 but
+# keeps the current kernel and does not touch the virtual packages,
+# e.g. 'linux-image-amd64', etc.
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep 'linux-image-.*-generic' \
+    | grep -v `uname -r` \
+    | xargs apt-get -y purge;
+
+# Remove linux modules
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep 'linux-modules-.*-generic' \
+    | grep -v `uname -r` \
+    | xargs apt-get -y purge;
+
+# Delete Linux source
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep linux-source \
+    | xargs apt-get -y purge;
+
+# Delete development packages
+dpkg --list \
+    | awk '{ print $2 }' \
+    | grep -- '-dev$' \
+    | xargs apt-get -y purge;
+
+# Delete X11 libraries
+apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
+
+# Delete obsolete networking
+apt-get -y purge ppp pppconfig pppoeconf;
+
+# Delete oddities
+apt-get -y purge popularity-contest installation-report command-not-found command-not-found-data friendly-recovery bash-completion fonts-ubuntu-font-family-console laptop-detect landscape-common;
+
+# Delete services we don't need installed by default
+apt-get -y purge exim4-base rpcbind
+
+# Exlude the files we don't need w/o uninstalling linux-firmware
+echo "==> Setup dpkg excludes for linux-firmware"
+cat <<_EOF_ | cat >> /etc/dpkg/dpkg.cfg.d/excludes
+#BENTO-BEGIN
+path-exclude=/lib/firmware/*
+path-exclude=/usr/share/doc/linux-firmware/*
+#BENTO-END
+_EOF_
+
+# Delete the massive firmware packages
+rm -rf /lib/firmware/*
+rm -rf /usr/share/doc/linux-firmware/*
+
+apt-get -y autoremove;
+apt-get -y clean;
+
+# Remove caches
+find /var/cache -type f -exec rm -rf {} \;
+
+# delete any logs that have built up during the install
+find /var/log/ -name *.log -exec rm -f {} \;
+
+# Blank netplan machine-id (DUID) so machines get unique ID generated on boot.
+truncate -s 0 /etc/machine-id

--- a/ubuntu-18.04-ppc64le-power9-openstack.json
+++ b/ubuntu-18.04-ppc64le-power9-openstack.json
@@ -31,7 +31,7 @@
       "headless": true,
       "vnc_bind_address": "0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "e7ad8c2f854b4587f9ca5c60f36b5ac4ede49829386653f2db404c3c43520a83",
+      "iso_checksum": "dc8aa1b7f9c7d7dd66bbde516e739166126faa55789da0cb63328a507ed5fc00",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/releases/18.04/release/ubuntu-18.04-server-ppc64el.iso",
       "output_directory": "packer-ubuntu-18.04-ppc64le-power9-openstack",

--- a/ubuntu-18.04-ppc64le-power9-openstack.json
+++ b/ubuntu-18.04-ppc64le-power9-openstack.json
@@ -33,7 +33,7 @@
       "http_directory": "http",
       "iso_checksum": "dc8aa1b7f9c7d7dd66bbde516e739166126faa55789da0cb63328a507ed5fc00",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/releases/18.04/release/ubuntu-18.04-server-ppc64el.iso",
+      "iso_url": "{{user `mirror`}}/releases/18.04/release/ubuntu-18.04.1-server-ppc64el.iso",
       "output_directory": "packer-ubuntu-18.04-ppc64le-power9-openstack",
       "shutdown_command": "echo 'ubuntu' | sudo -S shutdown -P now",
       "qemuargs": [

--- a/ubuntu-18.04-ppc64le-power9-openstack.json
+++ b/ubuntu-18.04-ppc64le-power9-openstack.json
@@ -1,0 +1,74 @@
+{
+  "builders": [
+    {
+      "boot_command": [
+        "<wait>",
+        "c<enter>",
+        "linux /install/vmlinux",
+        " auto",
+        " console-setup/ask_detect=false",
+        " console-setup/layoutcode=us",
+        " console-setup/modelcode=pc105",
+        " debconf/frontend=noninteractive",
+        " debian-installer=en_US.UTF-8",
+        " fb=false",
+        " kbd-chooser/method=us",
+        " keyboard-configuration/layout=USA",
+        " keyboard-configuration/variant=USA",
+        " locale=en_US.UTF-8",
+        " netcfg/get_hostname=unassigned-hostname",
+        " netcfg/get_domain=unassigned-domain",
+        " url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ubuntu-18.04/preseed-ppc64.cfg<wait>",
+        " ---",
+        "<enter><wait>",
+        "initrd /install/initrd.gz",
+        "<enter><wait>",
+        "boot<enter><wait>"
+      ],
+      "accelerator": "kvm",
+      "boot_wait": "6s",
+      "disk_size": 4096,
+      "headless": true,
+      "vnc_bind_address": "0.0.0.0",
+      "http_directory": "http",
+      "iso_checksum": "e7ad8c2f854b4587f9ca5c60f36b5ac4ede49829386653f2db404c3c43520a83",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/releases/18.04/release/ubuntu-18.04-server-ppc64el.iso",
+      "output_directory": "packer-ubuntu-18.04-ppc64le-power9-openstack",
+      "shutdown_command": "echo 'ubuntu' | sudo -S shutdown -P now",
+      "qemuargs": [
+        [ "-m", "2048M" ],
+        [ "-boot", "strict=on" ]
+      ],
+      "qemu_binary": "/usr/libexec/qemu-kvm",
+      "machine_type": "pseries",
+      "ssh_password": "ubuntu",
+      "ssh_port": 22,
+      "ssh_username": "ubuntu",
+      "ssh_wait_timeout": "10000s",
+      "type": "qemu",
+      "vm_name": "packer-ubuntu-18.04-ppc64le-power9-openstack"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo 'ubuntu' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+      "scripts": [
+        "scripts/ubuntu/update.sh",
+        "scripts/ubuntu/networking.sh",
+        "scripts/common/sshd.sh",
+        "scripts/common/vmtools.sh",
+        "scripts/ubuntu/openstack.sh",
+        "scripts/ubuntu/sudoers.sh",
+        "scripts/ubuntu/ppc.sh",
+        "scripts/ubuntu/cleanup-power9.sh",
+        "scripts/common/minimize.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "mirror": "http://cdimage.ubuntu.com",
+    "image_name": "Ubuntu 18.04 LE (POWER9)"
+  }
+}


### PR DESCRIPTION
The differences between the x64 template and ppc64le template are:
```diff
<       "iso_checksum": "e7ad8c2f854b4587f9ca5c60f36b5ac4ede49829386653f2db404c3c43520a83",
---
>       "iso_checksum": "dc8aa1b7f9c7d7dd66bbde516e739166126faa55789da0cb63328a507ed5fc00",
36,37c36,37
<       "iso_url": "{{user `mirror`}}/releases/18.04/release/ubuntu-18.04-server-ppc64el.iso",
<       "output_directory": "packer-ubuntu-18.04-ppc64le-openstack",
---
>       "iso_url": "{{user `mirror`}}/releases/18.04/release/ubuntu-18.04.1-server-ppc64el.iso",
>       "output_directory": "packer-ubuntu-18.04-ppc64le-power9-openstack",
50c50
<       "vm_name": "packer-ubuntu-18.04-ppc64le-openstack"
---
>       "vm_name": "packer-ubuntu-18.04-ppc64le-power9-openstack"
64c64
<         "scripts/ubuntu/cleanup.sh",
---
>         "scripts/ubuntu/cleanup-power9.sh",
72c72
<     "image_name": "Ubuntu 18.04 LE"
---
>     "image_name": "Ubuntu 18.04 LE (POWER9)"
```

The new cleanup script is just a copy of the normal ubuntu cleanup script, for now.