### PR TITLE
Upgrade to Chef 13.12.14 on CentOS hosts

### DIFF
--- a/centos-6-x86_64-openstack.json
+++ b/centos-6-x86_64-openstack.json
@@ -49,7 +49,7 @@
     }
   ],
   "variables": {
-    "chef_version": "13.8.5",
+    "chef_version": "13.12.14",
     "mirror": "http://centos.osuosl.org",
     "image_name": "CentOS 6.10"
   }

--- a/centos-7-ppc64-openstack.json
+++ b/centos-7-ppc64-openstack.json
@@ -42,7 +42,6 @@
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
-        "scripts/centos/chef-ppc64.sh",
         "scripts/centos/osuosl-altarch.sh",
         "scripts/centos/epel.sh",
         "scripts/centos/openstack.sh",

--- a/centos-7-ppc64le-openstack.json
+++ b/centos-7-ppc64le-openstack.json
@@ -42,7 +42,6 @@
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
-        "scripts/centos/chef-ppc64.sh",
         "scripts/centos/osuosl-altarch.sh",
         "scripts/centos/epel.sh",
         "scripts/centos/openstack.sh",

--- a/centos-7-x86_64-openstack.json
+++ b/centos-7-x86_64-openstack.json
@@ -47,7 +47,7 @@
     }
   ],
   "variables": {
-    "chef_version": "13.8.5",
+    "chef_version": "13.12.14",
     "mirror": "http://centos.osuosl.org",
     "image_name": "CentOS 7.6"
   }

--- a/centos-7-x86_64-pike-aio-openstack.json
+++ b/centos-7-x86_64-pike-aio-openstack.json
@@ -94,7 +94,7 @@
     }
   ],
   "variables": {
-    "chef_version": "13.8.5",
+    "chef_version": "13.12.14",
     "flavor": "m1.large",
     "suite": "volumes",
     "local_chef_dir": "chef",

--- a/centos-7-x86_64-pike-identity-openstack.json
+++ b/centos-7-x86_64-pike-identity-openstack.json
@@ -94,7 +94,7 @@
     }
   ],
   "variables": {
-    "chef_version": "13.8.5",
+    "chef_version": "13.12.14",
     "flavor": "m1.large",
     "suite": "volumes",
     "local_chef_dir": "chef",

--- a/scripts/centos/chef-ppc64.sh
+++ b/scripts/centos/chef-ppc64.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-curl -L http://ftp.osuosl.org/pub/osl/openpower/scripts/chef-install.sh | bash


### PR DESCRIPTION
- Remove chef from ppc64/ppc64le hosts as we don't need it plus this was pulling
  in a really outdated chef.