### PR TITLE
Debian: update 10.0 -> 10.1

### DIFF
--- a/debian-10-ppc64le-openstack.json
+++ b/debian-10-ppc64le-openstack.json
@@ -32,9 +32,9 @@
       "headless": true,
       "vnc_bind_address":"0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "ea456a84d1711d4e8c14175fcd9db4bac2e68af201a467ef9b2c23f0cc1a2b31",
+      "iso_checksum": "10523e6107cd0f7fd5a44bbd8033ae0418aab5e73678bec7470c43e4af725a68",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/10.0.0/ppc64el/iso-cd/debian-10.0.0-ppc64el-netinst.iso",
+      "iso_url": "{{user `mirror`}}/10.1.0/ppc64el/iso-cd/debian-10.1.0-ppc64el-netinst.iso",
       "output_directory": "packer-debian-10-ppc64le-openstack",
       "shutdown_command": "echo 'debian' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "debian",
@@ -71,7 +71,7 @@
   ],
   "variables": {
     "mirror": "http://debian.osuosl.org/debian-cdimage",
-    "image_name": "Debian 10.0 LE"
+    "image_name": "Debian 10.1 LE"
   }
 }
 

--- a/debian-10-x86_64-openstack.json
+++ b/debian-10-x86_64-openstack.json
@@ -27,9 +27,9 @@
       "headless": true,
       "vnc_bind_address":"0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "3dbb597b7f11dbda71cda08d4c1339c1eb565e784c75409987fa2b91182d9240",
+      "iso_checksum": "7915fdb77a0c2623b4481fc5f0a8052330defe1cde1e0834ff233818dc6f301e",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/10.0.0/amd64/iso-cd/debian-10.0.0-amd64-netinst.iso",
+      "iso_url": "{{user `mirror`}}/10.1.0/amd64/iso-cd/debian-10.1.0-amd64-netinst.iso",
       "output_directory": "packer-debian-10-x86_64-openstack",
       "shutdown_command": "echo 'debian' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "debian",
@@ -64,7 +64,7 @@
   ],
   "variables": {
     "mirror": "http://debian.osuosl.org/debian-cdimage",
-    "image_name": "Debian 10.0"
+    "image_name": "Debian 10.1"
   }
 }
 

--- a/debian-9-ppc64le-openstack.json
+++ b/debian-9-ppc64le-openstack.json
@@ -32,9 +32,9 @@
       "headless": true,
       "vnc_bind_address":"0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "3ecde213fabd4d8ebec02b745970942c177793c939ef6e3fe679a436bf2e104d",
+      "iso_checksum": "5d785af424e0259474f48bf55c5bf7aee19a945fdd74a3eb765f1c55f83cb554",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/release/9.9.0/ppc64el/iso-cd/debian-9.9.0-ppc64el-netinst.iso",
+      "iso_url": "{{user `mirror`}}/9.11.0/ppc64el/iso-cd/debian-9.11.0-ppc64el-netinst.iso",
       "output_directory": "packer-debian-9-ppc64le-openstack",
       "shutdown_command": "echo 'debian' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "debian",
@@ -70,8 +70,8 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdimage.debian.org/cdimage",
-    "image_name": "Debian 9.9 LE"
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "image_name": "Debian 9.11 LE"
   }
 }
 

--- a/debian-9-ppc64le-power9-openstack.json
+++ b/debian-9-ppc64le-power9-openstack.json
@@ -32,9 +32,9 @@
       "headless": true,
       "vnc_bind_address":"0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "3ecde213fabd4d8ebec02b745970942c177793c939ef6e3fe679a436bf2e104d",
+      "iso_checksum": "5d785af424e0259474f48bf55c5bf7aee19a945fdd74a3eb765f1c55f83cb554",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/release/9.9.0/ppc64el/iso-cd/debian-9.9.0-ppc64el-netinst.iso",
+      "iso_url": "{{user `mirror`}}/9.11.0/ppc64el/iso-cd/debian-9.11.0-ppc64el-netinst.iso",
       "output_directory": "packer-debian-9-ppc64le-power9-openstack",
       "shutdown_command": "echo 'debian' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "debian",
@@ -71,8 +71,8 @@
     }
   ],
   "variables": {
-    "mirror": "http://cdimage.debian.org/cdimage",
-    "image_name": "Debian 9.9 LE (POWER9)"
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "image_name": "Debian 9.11 LE (POWER9)"
   }
 }
 

--- a/debian-9-x86_64-openstack.json
+++ b/debian-9-x86_64-openstack.json
@@ -27,9 +27,9 @@
       "headless": true,
       "vnc_bind_address":"0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "d4a22c81c76a66558fb92e690ef70a5d67c685a08216701b15746586520f6e8e",
+      "iso_checksum": "9ae83aa5a732151ef2dc84538d1d4ffd6374df47cc01681da6348f9ec5a45bd4",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-netinst.iso",
+      "iso_url": "{{user `mirror`}}/9.11.0/amd64/iso-cd/debian-9.11.0-amd64-netinst.iso",
       "output_directory": "packer-debian-9-x86_64-openstack",
       "shutdown_command": "echo 'debian' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "debian",
@@ -63,8 +63,8 @@
     }
   ],
   "variables": {
-    "mirror": "http://debian.osuosl.org/debian-cdimage",
-    "image_name": "Debian 9.9"
+    "mirror": "http://cdimage.debian.org/cdimage/archive",
+    "image_name": "Debian 9.11"
   }
 }
 

--- a/scripts/debian/power9.sh
+++ b/scripts/debian/power9.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 
-echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease
+echo 'APT::Default-Release "oldstable";' > /etc/apt/apt.conf.d/99defaultrelease
 
 cat > /etc/apt/sources.list.d/testing.list <<EOF
 deb http://deb.debian.org/debian testing main contrib non-free


### PR DESCRIPTION
I was actually using this repo to build images for my own libvirt cluster, and found our Debian 10 images were out of date. I've only tested the x86_64 OpenStack image on libvirt, but everything seems to work fine.

the `pump` package has been [removed from the repos](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=935332) since it's unmaintained, I'm not sure if we need it on Debian 10 anyways since it can still get IP's from DHCP without it. ~~I've also removed `pump` from the Ubuntu images.~~ **Ubuntu will need to be fixed in a separate PR.**

I have not run openstack taster on these images.