### PR TITLE
Use dhclient by default with NetworkManager on CentOS 8

### DIFF
--- a/centos-8-x86_64-openstack.json
+++ b/centos-8-x86_64-openstack.json
@@ -39,6 +39,7 @@
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
         "scripts/common/chef.sh",
+        "scripts/centos/network-manager-dhcp-fix.sh",
         "scripts/centos/openstack.sh",
         "scripts/centos/cleanup.sh",
         "scripts/common/minimize.sh"

--- a/scripts/centos/network-manager-dhcp-fix.sh
+++ b/scripts/centos/network-manager-dhcp-fix.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eux
+
+yum install -y dhcp-client
+
+echo -en "[main]\ndhcp=dhclient\n" > /etc/NetworkManager/conf.d/dhcp.conf


### PR DESCRIPTION
This resolves an issue similar to this report [1] where a host cannot get an IP
address if there are more than one DHCP server on the same network.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=933930