### PR TITLE
Don't install chef on CentOS anymore

### DIFF
--- a/centos-7-x86_64-openstack.json
+++ b/centos-7-x86_64-openstack.json
@@ -29,16 +29,12 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [
-        "CHEF_VERSION={{user `chef_version`}}"
-      ],
       "execute_command": "echo 'centos' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/centos/osuosl.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
-        "scripts/common/chef.sh",
         "scripts/centos/openstack.sh",
         "scripts/centos/cleanup.sh",
         "scripts/common/minimize.sh"
@@ -47,7 +43,6 @@
     }
   ],
   "variables": {
-    "chef_version": "13.12.14",
     "mirror": "http://centos.osuosl.org",
     "image_name": "CentOS 7.7"
   }

--- a/centos-8-x86_64-openstack.json
+++ b/centos-8-x86_64-openstack.json
@@ -29,16 +29,12 @@
   ],
   "provisioners": [
     {
-      "environment_vars": [
-        "CHEF_VERSION={{user `chef_version`}}"
-      ],
       "execute_command": "echo 'centos' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
         "scripts/centos/osuosl.sh",
         "scripts/centos/fix-slow-dns.sh",
         "scripts/common/sshd.sh",
         "scripts/common/vmtools.sh",
-        "scripts/common/chef.sh",
         "scripts/centos/network-manager-dhcp-fix.sh",
         "scripts/centos/openstack.sh",
         "scripts/centos/cleanup.sh",
@@ -48,7 +44,6 @@
     }
   ],
   "variables": {
-    "chef_version": "13.12.14",
     "mirror": "http://centos.osuosl.org",
     "image_name": "CentOS 8.0"
   }


### PR DESCRIPTION
This will give us more room to install other versions of chef later. Plus it
doesn't take that long to install chef anymore.