### PR TITLE
Update Debian 11 images to 11.5

### DIFF
--- a/debian-11-aarch64-openstack.json
+++ b/debian-11-aarch64-openstack.json
@@ -31,9 +31,9 @@
       "headless": true,
       "vnc_bind_address":"0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "0b16a62b464ec2898feda0464da56ccfa3cdb311742758eaa15a00def0685c0a",
+      "iso_checksum": "70b19f7f0178d594b409822c724c2b7c0834716df1ad7e13dd10e1580380c7c9",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/bullseye/main/installer-arm64/20210731/images/netboot/mini.iso",
+      "iso_url": "{{user `mirror`}}/11.5.0/amd64/iso-cd/debian-11.5.0-arm64-netinst.iso",
       "output_directory": "packer-debian-11-aarch64-openstack",
       "shutdown_command": "echo 'debian' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "debian",
@@ -72,8 +72,8 @@
     }
   ],
   "variables": {
-    "mirror": "http://debian.osuosl.org/debian/dists",
-    "image_name": "Debian 11.0"
+    "mirror": "http://debian.osuosl.org/debian-cdimage",
+    "image_name": "Debian 11.5"
   }
 }
 

--- a/debian-11-ppc64le-openstack.json
+++ b/debian-11-ppc64le-openstack.json
@@ -32,9 +32,9 @@
       "headless": true,
       "vnc_bind_address":"0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "6ef24c46163ec0426cc1cd310afd5ad6cf53a5965a0666af69ad88e0fd41f348",
+      "iso_checksum": "e8ad422aadae9408c59c6f6140b3d1b6098fa94f9f2aa00bc743d96c025ea2af",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/11.0.0/ppc64el/iso-cd/debian-11.0.0-ppc64el-netinst.iso",
+      "iso_url": "{{user `mirror`}}/11.5.0/ppc64el/iso-cd/debian-11.5.0-ppc64el-netinst.iso",
       "output_directory": "packer-debian-11-ppc64le-openstack",
       "shutdown_command": "echo 'debian' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "debian",
@@ -71,7 +71,7 @@
   ],
   "variables": {
     "mirror": "http://debian.osuosl.org/debian-cdimage",
-    "image_name": "Debian 11.0 LE"
+    "image_name": "Debian 11.5 LE"
   }
 }
 

--- a/debian-11-x86_64-openstack.json
+++ b/debian-11-x86_64-openstack.json
@@ -27,9 +27,9 @@
       "headless": true,
       "vnc_bind_address":"0.0.0.0",
       "http_directory": "http",
-      "iso_checksum": "ae6d563d2444665316901fe7091059ac34b8f67ba30f9159f7cef7d2fdc5bf8a",
+      "iso_checksum": "e307d0e583b4a8f7e5b436f8413d4707dd4242b70aea61eb08591dc0378522f3",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/11.0.0/amd64/iso-cd/debian-11.0.0-amd64-netinst.iso",
+      "iso_url": "{{user `mirror`}}/11.5.0/amd64/iso-cd/debian-11.5.0-amd64-netinst.iso",
       "output_directory": "packer-debian-11-x86_64-openstack",
       "shutdown_command": "echo 'debian' | sudo -S /sbin/shutdown -hP now",
       "ssh_password": "debian",
@@ -64,7 +64,7 @@
   ],
   "variables": {
     "mirror": "http://debian.osuosl.org/debian-cdimage",
-    "image_name": "Debian 11.0"
+    "image_name": "Debian 11.5"
   }
 }
 


### PR DESCRIPTION
We consume these for our CI runners at freedesktop-sdk: https://gitlab.com/freedesktop-sdk/infrastructure/infrastructure-images-packer/-/blob/main/fdsdk-image-osuosl.pkr.hcl#L25

It would be nice to have a slightly more up to date base image to work with.